### PR TITLE
pixi: add support for Linux ARM

### DIFF
--- a/.github/workflows/pixi-packages.yml
+++ b/.github/workflows/pixi-packages.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-15]
+        runs-on: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         package_variant:
           - default
           - freethreading
@@ -36,9 +36,7 @@ jobs:
 
     - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
       with:
-        # FIXME regression in 0.63.0:
-        # https://github.com/prefix-dev/rattler-build/issues/2094
-        pixi-version: v0.62.2
+        pixi-version: v0.63.2
         run-install: false
 
     - name: Build

--- a/pixi-packages/asan/pixi.toml
+++ b/pixi-packages/asan/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-platforms = ["osx-arm64", "linux-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 preview = ["pixi-build"]
 
 [package.build]

--- a/pixi-packages/default/pixi.toml
+++ b/pixi-packages/default/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-platforms = ["osx-arm64", "linux-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 preview = ["pixi-build"]
 
 [package.build]

--- a/pixi-packages/freethreading/pixi.toml
+++ b/pixi-packages/freethreading/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-platforms = ["osx-arm64", "linux-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 preview = ["pixi-build"]
 
 [package.build]

--- a/pixi-packages/tsan-freethreading/pixi.toml
+++ b/pixi-packages/tsan-freethreading/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-platforms = ["osx-arm64", "linux-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 preview = ["pixi-build"]
 
 [package.build]


### PR DESCRIPTION
Add support for Linux ARM to pixi recipes.
Also tested downstream in https://github.com/crusaderky/cpython-pixi/.

Notes:
- MacOS Intel works for cpython, but not for numpy ASAN/TSAN: https://github.com/numpy/numpy/pull/30510#issuecomment-3785350194
- Windows is non-trivially broken in cpython
